### PR TITLE
Fix 2D/3D spot detection indexing bugs

### DIFF
--- a/source/spot_detection_tracking/2d_spot_detection.py
+++ b/source/spot_detection_tracking/2d_spot_detection.py
@@ -174,8 +174,8 @@ def main():
                     np.max(movie[idx], axis=0), vmax=np.quantile(movie[idx], 0.999)
                 )
                 ax[0].scatter(
-                    df[df["slice" == idx]]["x"],
-                    df[df["slice" == idx]]["y"],
+                    df[df["slice"] == idx]["x"],
+                    df[df["slice"] == idx]["y"],
                     color="red",
                     marker="+",
                 )
@@ -183,8 +183,8 @@ def main():
                     np.max(movie[idx], axis=0), vmax=np.quantile(movie[idx], 0.999)
                 )
                 ax[1].scatter(
-                    df[df["slice" == idx]]["x"],
-                    df[df["slice" == idx]]["y"],
+                    df[df["slice"] == idx]["x"],
+                    df[df["slice"] == idx]["y"],
                     color="red",
                     marker="+",
                 )

--- a/source/spot_detection_tracking/3d_spot_detection.py
+++ b/source/spot_detection_tracking/3d_spot_detection.py
@@ -211,7 +211,7 @@ def main():
     frame = 0
 
     for coord in coord_list_gauss:
-        if len(coord > 0):
+        if len(coord) > 0:
             df_new = pd.DataFrame(coord, columns=["x", "y", "z"])
             df_new["frame"] = frame
             df = pd.concat([df, df_new])


### PR DESCRIPTION
## Summary
- fix slicing condition when indexing points in 2D spot detection
- correct length check when exporting 3D detection results

## Testing
- `python -m py_compile $(find source -name "*.py" | grep -v trackmate_tracking_gap.py | grep -v assign_cellids.py)`

------
https://chatgpt.com/codex/tasks/task_b_6849abd2e2f0832ab58f77603483172e